### PR TITLE
fix: report disconnected device status

### DIFF
--- a/libs/sony-core/src/IpcProtocol.cpp
+++ b/libs/sony-core/src/IpcProtocol.cpp
@@ -147,7 +147,23 @@ IpcResponse IpcProtocol::execute(const IpcCommand& cmd, IDeviceService& service)
     }
 
     auto* dev = service.activeDevice();
-    if (!dev || !dev->isConnected()) {
+
+    // Status is useful precisely when the transport is no longer connected.
+    // Keep it outside the general command guard so callers can distinguish a
+    // missing selection from a selected device whose link has dropped.
+    if (cmd.type == IpcCommandType::Status) {
+        if (!dev) {
+            resp.success = false;
+            resp.message = "No device selected";
+            return resp;
+        }
+        resp.success = service.isConnected();
+        resp.message = resp.success ? "Connected" : "Device selected but disconnected";
+        resp.data = "model=" + dev->name();
+        return resp;
+    }
+
+    if (!dev || !service.isConnected()) {
         resp.success = false;
         resp.message = "No device connected";
         return resp;
@@ -320,13 +336,6 @@ IpcResponse IpcProtocol::execute(const IpcCommand& cmd, IDeviceService& service)
             dev->setAutoPowerOff(idx);
             resp.success = true;
             resp.message = "Auto power off set to index " + std::to_string(idx);
-            return resp;
-        }
-
-        case IpcCommandType::Status: {
-            resp.success = true;
-            resp.message = "Connected";
-            resp.data = "model=" + dev->name();
             return resp;
         }
 

--- a/tests/core/IpcProtocolTests.cpp
+++ b/tests/core/IpcProtocolTests.cpp
@@ -195,6 +195,23 @@ TEST_CASE("IpcProtocol execution through DeviceService", "[core][ipc]") {
         CHECK(resp.message == "No device connected");
     }
 
+    SECTION("status distinguishes no selection from a dropped connection") {
+        auto status = IpcProtocol::parseCommand("status");
+        auto noSelection = IpcProtocol::execute(status, service);
+        CHECK_FALSE(noSelection.success);
+        CHECK(noSelection.message == "No device selected");
+        CHECK(noSelection.data.empty());
+
+        service.connect(DeviceAddress("11:22:33:44:55:66"), "WH-1000XM5");
+        REQUIRE(service.isConnected());
+        service.disconnect();
+
+        auto disconnected = IpcProtocol::execute(status, service);
+        CHECK_FALSE(disconnected.success);
+        CHECK(disconnected.message == "Device selected but disconnected");
+        CHECK(disconnected.data == "model=WH-1000XM5");
+    }
+
     SECTION("connected device executes commands") {
         service.connect(DeviceAddress("11:22:33:44:55:66"), "WH-1000XM5");
         REQUIRE(service.isConnected());


### PR DESCRIPTION
## What changed

`status` was handled only after the generic connected-device guard, so a selected device with a dropped transport was reported the same way as every other unavailable command. This change handles `status` first and uses the service connection state to distinguish:

- no device selected
- a selected device whose transport is disconnected
- an active connection, preserving the existing response

The disconnected response keeps the selected model name so callers can tell which device lost its link.

## Tests

- `IpcProtocol execution through DeviceService`: passed, including the new no-selection and dropped-connection cases
- `ctest --test-dir build-msvc -E "IpcServer and IpcClient end-to-end communication over socket" --output-on-failure`: 113/113 passed on MSVC 19.44
- `git diff --check`: passed

The full Windows CTest run still has the existing socket test failure where `client.isDaemonRunning()` remains false. It reproduces on the unchanged baseline and is kept separate from this IPC status fix.

Fixes #30