### PR TITLE
fix(protocol): read battery, noise control and equalizer on legacy devices

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ real hardware.
 | **WH-1000XM6** | V2 | ⚠️ Partially working | Controls work; **equalizer has no effect** ([#10](../../issues/10)), battery intermittent ([#11](../../issues/11)) |
 | **WF-1000XM6** | V2 | ✅ Verified | Community report |
 | **MDR-1000X** | V1 | ❌ Known broken | Shows as disconnected, no controls work ([#12](../../issues/12)) |
-| **WH-1000XM4** | V1 | 🟡 Untested | Expected to behave like the XM3 |
+| **WH-1000XM4** | V1 | ✅ Verified | Community report (firmware 3.0.1, Windows): battery, noise control readback, EQ + Clear Bass, firmware, codec |
 | WF-1000XM5, WF-1000XM4 | V2 | 🟡 Untested | TWS battery reporting unverified |
 | WH-CH720N, ULT WEAR, LinkBuds S, WF-C700N | V2 | 🟡 Untested | |
 | WH-XB910N, WH-CH520 | V2 | 🟡 Untested | |
@@ -66,8 +66,9 @@ real hardware.
 **State and connection handling:** the Qt app now uses structured snapshots,
 updates from supported device notifications, and periodic refreshes. It shows
 unknown readings and command errors explicitly. The daemon retries unavailable
-headphones automatically. V1 noise-control readback remains undecoded; successful
-writes are shown, but an initial mode is not guessed. Model-specific XM6 protocol
+headphones automatically. V1 battery, noise-control and equalizer readback is
+decoded and verified on a WH-1000XM4; the XM3 uses the same opcodes but has not
+been re-tested since. Model-specific XM6 protocol
 failures still need hardware verification. See [IPC and connection lifecycle](docs/ipc-and-lifecycle.md).
 
 Running something not listed, or listed as untested? Please

--- a/docs/device-matrix.md
+++ b/docs/device-matrix.md
@@ -18,7 +18,7 @@ This document tracks hardware-level verification and protocol capability support
 | Device | Protocol | Connection | Battery | ANC | Ambient | EQ | DSEE | Firmware | Codec | Speak-to-Chat | Auto Power-Off | Tested Firmware | Tester |
 | :--- | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: | :---: |
 | **WH-1000XM3** | V1 | RFCOMM | Verified | Verified | Verified | N/A (V1) | N/A (V1) | Unknown | SBC, AAC, LDAC, aptX | N/A | N/A | 4.5.2 | Community |
-| **WH-1000XM4** | V1 | RFCOMM | Verified | Verified | Verified | N/A (V1) | N/A (V1) | Unknown | SBC, AAC, LDAC | Partially Verified | Partially Verified | 2.5.0 | Baseline |
+| **WH-1000XM4** | V1 | RFCOMM | Verified | Verified | Verified | Verified | Not implemented (V1) | Verified | AAC verified | N/A | Not implemented (V1) | 3.0.1 | Community (Windows) |
 | **WH-1000XM5** | V2 | RFCOMM | Verified | Verified | Verified | Verified | Verified | Verified | SBC, AAC, LDAC | Verified | Verified | 2.3.1 | Core Dev |
 | **WH-1000XM6** | V2 | RFCOMM | Expected | Expected | Expected | Expected | Expected | Expected | Expected | Expected | Expected | — | Unreleased |
 | **WF-1000XM4** | V2 | RFCOMM | Expected (Dual+Case) | Expected | Expected | Expected | Expected | Expected | SBC, AAC, LDAC | Expected | Expected | — | Awaiting HW |
@@ -33,9 +33,12 @@ This document tracks hardware-level verification and protocol capability support
 
 ### Protocol V1 (e.g. WH-1000XM3, WH-1000XM4 legacy)
 - Fixed command lengths without variable payloads.
-- Single battery level query.
+- Battery query `0x10 <type>` (returns `0x11`): type `0x00` single, `0x01` dual, `0x02` case.
+- Noise control / ambient via `0x66` / `0x67` / `0x68` with inquired type `0x02`: effect byte, then dual/single (`0x02` = NC, `0x00` = ambient at the trailing level).
+- 5-band equalizer with Clear Bass via `0x56` / `0x57` / `0x58` with inquired type `0x01` (V2 uses `0x00`).
+- Firmware `0x04 0x02` (returns `0x05`), codec `0x18 0x00` (returns `0x19`).
 - **Opcode `0x22` is POWER OFF** — must NEVER be transmitted to a V1 device to query battery.
-- Equalizer and DSEE control handled via separate legacy control messages or not exposed in standard V1 profile.
+- DSEE (`0xe6 0x02`) and auto power-off (`0xf6 0x04`) do answer on a WH-1000XM4 but are not decoded or exposed yet.
 
 ### Protocol V2 (e.g. WH-1000XM5, WF-1000XM4/M5, LinkBuds, ULT WEAR)
 - Extended variable-length payload structures.
@@ -80,7 +83,7 @@ To validate a newly connected physical device:
    sonyctl anc off
    ```
 
-6. **Test Equalizer (V2 devices)**:
+6. **Test Equalizer (V2 devices and WH-1000XM4)**:
    ```bash
    sonyctl eq get
    sonyctl eq preset bass-boost

--- a/docs/ipc-and-lifecycle.md
+++ b/docs/ipc-and-lifecycle.md
@@ -25,8 +25,8 @@ Known connected sessions rotate settings reads in separate maintenance steps,
 nominally within five seconds when the device answers promptly. Battery refreshes
 every 30 seconds. Unsupported profile features are not probed. Timeouts extend
 these intervals rather than accumulating overlapping requests. V1 does not send
-the V2 battery opcode, and V1's undecoded noise-control readback stays unknown until
-a successful write. Protocol similarity is not hardware verification.
+the V2 battery opcode; it reads battery, noise control and equalizer through its
+own legacy opcodes. Protocol similarity is not hardware verification.
 
 `sonyctl --direct` refuses to run while a daemon is reachable at the selected socket.
 This also applies to a disconnected daemon that may be reconnecting. Stop the daemon

--- a/docs/technical-debt.md
+++ b/docs/technical-debt.md
@@ -7,8 +7,9 @@ no hardware verification or release publication is implied by the automated test
 ## Highest priority
 
 1. **Hardware acceptance and protocol gaps (#8–12).** Test reconnect, physical NC
-   button changes, battery refresh, and commands on XM3/XM5 hardware. V1 NC readback
-   is still undecoded and now honestly shown as unknown until a successful write.
+   button changes, battery refresh, and commands on XM3/XM5 hardware. V1 battery,
+   NC and EQ readback is decoded and verified on an XM4; the XM3 still needs a
+   re-test on the same path, and V1 DSEE / auto power-off remain unimplemented.
    XM6 EQ/read timeouts and MDR-1000X connectivity remain unresolved. Decode the
    reported captures and add literal packet fixtures before changing model claims.
    ACK receipt still cannot establish that an EQ change had an audible effect.

--- a/libs/sony-core/src/SonyDevice.cpp
+++ b/libs/sony-core/src/SonyDevice.cpp
@@ -193,14 +193,6 @@ void SonyDevice::refreshBattery() {
 void SonyDevice::refreshNoiseControl() {
     if (!_protocol) return;
     if (!_capabilities.noiseCancelling && !_capabilities.ambientSound) return;
-    // V1's protocol getter returns a local cache; its readback layout is not
-    // decoded. Preserve confirmed writes and never advertise the default as a read.
-    if (_version == SonyProtocolVersion::V1) {
-        std::lock_guard lock(_stateMutex);
-        if (!_state.features["noiseControl"].lastSuccessMs)
-            _state.features["noiseControl"].error = "Legacy noise-control readback is not decoded";
-        return;
-    }
     try {
         auto nc = _protocol->getNoiseControl();
         {

--- a/libs/sony-protocol/include/sony/protocol/ProtocolV1.h
+++ b/libs/sony-protocol/include/sony/protocol/ProtocolV1.h
@@ -2,10 +2,14 @@
 
 #include "IProtocol.h"
 #include "SonyProtocolSession.h"
-#include <mutex>
 
 namespace sony::protocol {
 
+// Legacy command set spoken by WH-1000XM3/XM4 and their contemporaries.
+//
+// Critical: opcode 0x22 is POWER OFF on this generation (it is BATTERY GET on
+// V2). Nothing in this class may ever emit it; the battery lives behind
+// 0x10/0x11 instead.
 class ProtocolV1 : public IProtocol {
 public:
     explicit ProtocolV1(SonyProtocolSession& session);
@@ -17,8 +21,6 @@ public:
 
     void initDevice() override;
 
-    // Critical: V1 does not support battery queries over MDR.
-    // Opcode 0x22 in V1 is Power Off, so getBattery() NEVER sends 0x22.
     BatteryState getBattery() override;
 
     NoiseControlState getNoiseControl() override;
@@ -49,9 +51,6 @@ public:
 
 private:
     SonyProtocolSession& _session;
-    std::mutex _mutex;
-    BatteryState _batteryState;
-    NoiseControlState _noiseControlState;
 };
 
 } // namespace sony::protocol

--- a/libs/sony-protocol/src/DeviceProfileRegistry.cpp
+++ b/libs/sony-protocol/src/DeviceProfileRegistry.cpp
@@ -40,6 +40,8 @@ const std::vector<DeviceProfile>& getStaticProfiles() {
             }
         },
         // WH-1000XM4 (V1 protocol, ANC/Ambient, Single battery, wear sensor, multipoint)
+        // Battery, EQ + Clear Bass, firmware and codec readback verified on
+        // hardware (firmware 3.0.1) over the legacy V1 opcodes.
         DeviceProfile{
             .model = SonyModel::WH1000XM4,
             .protocol = SonyProtocolVersion::V1,
@@ -49,14 +51,14 @@ const std::vector<DeviceProfile>& getStaticProfiles() {
                 .noiseCancelling = true,
                 .ambientSound = true,
                 .focusOnVoice = true,
-                .equalizer = false,
-                .clearBass = false,
+                .equalizer = true,
+                .clearBass = true,
                 .dsee = false,
                 .speakToChat = false,
                 .adaptiveVolume = false,
                 .autoPowerOff = false,
-                .firmwareInfo = false,
-                .codecInfo = false,
+                .firmwareInfo = true,
+                .codecInfo = true,
                 .wearSensor = true,
                 .multipoint = true
             }

--- a/libs/sony-protocol/src/ProtocolHelpers.h
+++ b/libs/sony-protocol/src/ProtocolHelpers.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <algorithm>
+#include <cstdint>
+#include <string>
+
+// Byte-level helpers shared by the V1 and V2 command sets. Both generations
+// encode equalizer values as value+10 and report the same codec codes.
+namespace sony::protocol::detail {
+
+inline std::string codecName(uint8_t code) {
+    switch (code) {
+        case 0x01: return "SBC";
+        case 0x02: return "AAC";
+        case 0x10: return "LDAC";
+        case 0x20: return "aptX";
+        case 0x21: return "aptX HD";
+        default:   return "";
+    }
+}
+
+inline uint8_t clampEqValue(int v) {
+    return static_cast<uint8_t>(std::max(-10, std::min(10, v)) + 10);
+}
+
+} // namespace sony::protocol::detail

--- a/libs/sony-protocol/src/ProtocolV1.cpp
+++ b/libs/sony-protocol/src/ProtocolV1.cpp
@@ -1,80 +1,205 @@
 #include "sony/protocol/ProtocolV1.h"
+#include "ProtocolHelpers.h"
+
+#include <algorithm>
+#include <chrono>
+
+// Byte layouts below match Client/CommandSerializer.cpp (the legacy client,
+// exercised on WH-1000XM3 hardware for years) and Gadgetbridge's
+// SonyProtocolImplV1. Every GET was additionally replayed against a
+// WH-1000XM4 on firmware 3.0.1 before being trusted here.
+//
+// CRITICAL: opcode 0x22 is POWER OFF on this generation. It must never be
+// sent from this file; ProtocolV1Tests pins that for the battery path.
 
 namespace sony::protocol {
+
+using detail::clampEqValue;
+using detail::codecName;
+
+namespace {
+
+constexpr uint8_t kNcAsmInquired = 0x02;  // NOISE_CANCELLING_AND_AMBIENT_SOUND_MODE
+constexpr uint8_t kEqInquired = 0x01;     // PRESET_EQ
+
+constexpr uint8_t kEffectOff = 0x00;
+constexpr uint8_t kEffectAdjustmentCompletion = 0x11;
+constexpr uint8_t kLevelAdjustment = 0x01;
+constexpr uint8_t kDualSingleOff = 0x00;   // ambient sound passthrough
+constexpr uint8_t kDualSingleDual = 0x02;  // noise cancelling
+
+constexpr auto kTimeout = std::chrono::milliseconds(1000);
+
+} // namespace
 
 ProtocolV1::ProtocolV1(SonyProtocolSession& session)
     : _session(session) {}
 
 void ProtocolV1::initDevice() {
-    // V1 does not require an init handshake like V2; best-effort poll of ambient state
+    // V1 does not require an init handshake like V2; best-effort poll of
+    // ambient state. The first reply after connecting is the slow one on a
+    // WH-1000XM4 (well past 500 ms), and giving up early leaves its late ACK
+    // and data frame to collide with the next request, so wait as long as
+    // any other query does.
     try {
         _session.sendAndAwaitResponse(
-            SonyFrame{ .type = DataType::DataMdr, .payload = {0x66, 0x02} },
+            SonyFrame{ .type = DataType::DataMdr, .payload = {0x66, kNcAsmInquired} },
             0x67,
-            -1,
-            std::chrono::milliseconds(500)
+            kNcAsmInquired,
+            std::chrono::milliseconds(1500)
         );
     } catch (const SonyException&) {}
 }
 
 BatteryState ProtocolV1::getBattery() {
-    // CRITICAL REGRESSION SAFETY:
-    // In V1, opcode 0x22 is POWER OFF. In V2, 0x22 is BATTERY GET.
-    // Under NO circumstances may opcode 0x22 be sent to a V1 session here!
-    // V1 devices report battery via unsolicited RFCOMM/HFP frames or notifications.
-    std::lock_guard lock(_mutex);
-    return _batteryState;
+    // GET 10 <type> -> RET 11 <type> ..., type 0x00 single, 0x01 dual (L/R),
+    // 0x02 case. Over-ear models answer every type and echo the single reading
+    // into the left slot, so the single reading is authoritative when it
+    // arrives and dual/case are only consulted for earbuds.
+    BatteryState state;
+
+    // 1. Single battery: GET 10 00 -> RET 11 00 <level> <charging>
+    try {
+        auto resp = _session.sendAndAwaitResponse(
+            SonyFrame{ .type = DataType::DataMdr, .payload = {0x10, 0x00} },
+            0x11, 0x00, kTimeout);
+        if (resp.payload.size() >= 4) {
+            state.main = static_cast<int>(resp.payload[2]);
+            state.charging = (resp.payload[3] == 1);
+            return state;
+        }
+    } catch (const SonyException&) {}
+
+    // 2. Dual L/R battery: GET 10 01 -> RET 11 01 <Llvl> <Lchg> <Rlvl> <Rchg>
+    try {
+        auto resp = _session.sendAndAwaitResponse(
+            SonyFrame{ .type = DataType::DataMdr, .payload = {0x10, 0x01} },
+            0x11, 0x01, kTimeout);
+        if (resp.payload.size() >= 6) {
+            const int left = static_cast<int>(resp.payload[2]);
+            const int right = static_cast<int>(resp.payload[4]);
+            state.charging = (resp.payload[3] == 1 || resp.payload[5] == 1);
+            if (right == 0 && left > 0) {
+                // Over-ear models answer the dual query too, echoing their
+                // single cell into the left slot with an empty right one.
+                // Reporting min(left, right) there would read as 0%.
+                state.main = left;
+            } else {
+                state.left = left;
+                state.right = right;
+                state.main = std::min(left, right);
+            }
+        }
+    } catch (const SonyException&) {}
+
+    // 3. Case battery: GET 10 02 -> RET 11 02 <level> <charging>
+    try {
+        auto resp = _session.sendAndAwaitResponse(
+            SonyFrame{ .type = DataType::DataMdr, .payload = {0x10, 0x02} },
+            0x11, 0x02, kTimeout);
+        if (resp.payload.size() >= 4) {
+            state.caseBattery = static_cast<int>(resp.payload[2]);
+        }
+    } catch (const SonyException&) {}
+
+    return state;
 }
 
 NoiseControlState ProtocolV1::getNoiseControl() {
-    try {
-        _session.sendAndAwaitResponse(
-            SonyFrame{ .type = DataType::DataMdr, .payload = {0x66, 0x02} },
-            0x67,
-            -1,
-            std::chrono::milliseconds(1000)
-        );
-    } catch (const SonyException&) {}
+    // GET 66 02 -> RET 67 02 <effect> <ncSettingType> <dualSingle> <asmSettingType> <asmId> <asmLevel>
+    // effect 0 is off. Otherwise dualSingle selects the mode: 0 is ambient
+    // sound at <asmLevel>, 1 (single) and 2 (dual) are noise cancelling.
+    auto resp = _session.sendAndAwaitResponse(
+        SonyFrame{ .type = DataType::DataMdr, .payload = {0x66, kNcAsmInquired} },
+        0x67, kNcAsmInquired, kTimeout);
 
-    std::lock_guard lock(_mutex);
-    return _noiseControlState;
+    if (resp.payload.size() < 8 || resp.payload[1] != kNcAsmInquired)
+        throw SonyException(SonyErrorCode::InvalidResponse, "Malformed noise-control response");
+
+    const bool on = resp.payload[2] != kEffectOff;
+    const bool ambient = resp.payload[4] == kDualSingleOff;
+    const bool voice = resp.payload[6] == 1;
+    const int level = static_cast<int>(resp.payload[7]);
+
+    NoiseControlState state;
+    if (!on) {
+        state.mode = NoiseControlMode::Off;
+    } else if (ambient) {
+        state.mode = NoiseControlMode::Ambient;
+    } else {
+        state.mode = NoiseControlMode::NoiseCancelling;
+    }
+    state.ambientLevel = (state.mode == NoiseControlMode::Ambient) ? level : 0;
+    state.focusOnVoice = voice;
+    return state;
 }
 
 void ProtocolV1::setNoiseControl(const NoiseControlState& state) {
-    uint8_t effect = (state.mode == NoiseControlMode::Off) ? 0 : 17; // ADJUSTMENT_COMPLETION
-    uint8_t ncSettingType = 1; // LEVEL_ADJUSTMENT
-    uint8_t asmSettingType = 1; // LEVEL_ADJUSTMENT
-    uint8_t asmId = state.focusOnVoice ? 1 : 0;
-    int8_t asmLevel = (state.mode == NoiseControlMode::Ambient) ? static_cast<int8_t>(state.ambientLevel) : -1;
-    uint8_t dualSingle = (asmLevel == -1) ? 0 : (asmLevel == 1 ? 1 : 2);
+    // SET 68 02 <effect> 01 <dualSingle> 01 <asmId> <asmLevel>
+    // Noise cancelling is dual NC with the level at 0; ambient sound is
+    // dual/single OFF with the level in the last byte. This is what the legacy
+    // client has always sent and what the headset echoes back on GET.
+    const bool off = state.mode == NoiseControlMode::Off;
+    const bool ambient = state.mode == NoiseControlMode::Ambient;
+    const uint8_t level = ambient ? static_cast<uint8_t>(std::clamp(state.ambientLevel, 1, 20)) : 0;
 
     std::vector<uint8_t> payload = {
-        0x68, // NCASM_SET_PARAM (104)
-        0x02, // NOISE_CANCELLING_AND_AMBIENT_SOUND_MODE
-        effect,
-        ncSettingType,
-        dualSingle,
-        asmSettingType,
-        asmId,
-        static_cast<uint8_t>(asmLevel)
+        0x68,
+        kNcAsmInquired,
+        off ? kEffectOff : kEffectAdjustmentCompletion,
+        kLevelAdjustment,
+        (ambient || off) ? kDualSingleOff : kDualSingleDual,
+        kLevelAdjustment,
+        static_cast<uint8_t>(state.focusOnVoice ? 1 : 0),
+        level
     };
 
     _session.send(SonyFrame{ .type = DataType::DataMdr, .payload = std::move(payload) });
-
-    std::lock_guard lock(_mutex);
-    _noiseControlState = state;
 }
 
 EqualizerState ProtocolV1::getEqualizer() {
-    throw SonyException(SonyErrorCode::Unsupported, "Equalizer query is not supported on Protocol V1");
+    // GET 56 01 -> RET 57 01 <preset> 06 <bass+10> <b1..b5 +10>
+    // Same table as V2, behind inquired type 0x01 (PRESET_EQ) instead of 0x00.
+    auto resp = _session.sendAndAwaitResponse(
+        SonyFrame{ .type = DataType::DataMdr, .payload = {0x56, kEqInquired} },
+        0x57, kEqInquired, kTimeout);
+
+    if (resp.payload.size() < 10 || resp.payload[1] != kEqInquired)
+        throw SonyException(SonyErrorCode::InvalidResponse, "Incomplete equalizer response");
+
+    EqualizerState state;
+    state.preset = static_cast<int>(resp.payload[2]);
+    state.clearBass = static_cast<int>(resp.payload[4]) - 10;
+    for (size_t i = 0; i < 5; ++i) {
+        state.bands[i] = static_cast<int>(resp.payload[5 + i]) - 10;
+    }
+    return state;
 }
 
-void ProtocolV1::setEqualizerPreset(int /*preset*/) {
-    throw SonyException(SonyErrorCode::Unsupported, "Equalizer preset is not supported on Protocol V1");
+void ProtocolV1::setEqualizerPreset(int preset) {
+    // SET preset: 58 01 <preset> 00
+    std::vector<uint8_t> payload = {
+        0x58,
+        kEqInquired,
+        static_cast<uint8_t>(preset),
+        0x00
+    };
+    _session.send(SonyFrame{ .type = DataType::DataMdr, .payload = std::move(payload) });
 }
 
-void ProtocolV1::setEqualizerCustom(int /*clearBass*/, const std::array<int, 5>& /*bands*/) {
-    throw SonyException(SonyErrorCode::Unsupported, "Custom equalizer is not supported on Protocol V1");
+void ProtocolV1::setEqualizerCustom(int clearBass, const std::array<int, 5>& bands) {
+    // SET custom: 58 01 A0 06 <clearBass+10> <b1..b5 +10>
+    std::vector<uint8_t> payload = {
+        0x58,
+        kEqInquired,
+        0xa0,
+        0x06,
+        clampEqValue(clearBass)
+    };
+    for (int b : bands) {
+        payload.push_back(clampEqValue(b));
+    }
+    _session.send(SonyFrame{ .type = DataType::DataMdr, .payload = std::move(payload) });
 }
 
 bool ProtocolV1::getDsee() {
@@ -86,11 +211,25 @@ void ProtocolV1::setDsee(bool /*enabled*/) {
 }
 
 std::string ProtocolV1::getFirmwareVersion() {
-    throw SonyException(SonyErrorCode::Unsupported, "Firmware query is not supported on Protocol V1");
+    // GET 04 02 -> RET 05 02 <len> <ascii version...>
+    auto resp = _session.sendAndAwaitResponse(
+        SonyFrame{ .type = DataType::DataMdr, .payload = {0x04, 0x02} },
+        0x05, -1, kTimeout);
+    if (resp.payload.size() > 3) {
+        return std::string(resp.payload.begin() + 3, resp.payload.end());
+    }
+    return "";
 }
 
 std::string ProtocolV1::getCodec() {
-    throw SonyException(SonyErrorCode::Unsupported, "Codec query is not supported on Protocol V1");
+    // GET 18 00 -> RET 19 00 <codec>
+    auto resp = _session.sendAndAwaitResponse(
+        SonyFrame{ .type = DataType::DataMdr, .payload = {0x18, 0x00} },
+        0x19, -1, kTimeout);
+    if (resp.payload.size() >= 3) {
+        return codecName(resp.payload[2]);
+    }
+    return "";
 }
 
 int ProtocolV1::getAutoPowerOff() {

--- a/libs/sony-protocol/src/ProtocolV2.cpp
+++ b/libs/sony-protocol/src/ProtocolV2.cpp
@@ -1,7 +1,11 @@
 #include "sony/protocol/ProtocolV2.h"
+#include "ProtocolHelpers.h"
 #include <algorithm>
 
 namespace sony::protocol {
+
+using detail::clampEqValue;
+using detail::codecName;
 
 namespace {
 
@@ -17,21 +21,6 @@ int apoIndexFromCode(uint8_t c0, uint8_t c1) {
         }
     }
     return 0;
-}
-
-std::string codecName(uint8_t code) {
-    switch (code) {
-        case 0x01: return "SBC";
-        case 0x02: return "AAC";
-        case 0x10: return "LDAC";
-        case 0x20: return "aptX";
-        case 0x21: return "aptX HD";
-        default:   return "";
-    }
-}
-
-uint8_t clampEqValue(int v) {
-    return static_cast<uint8_t>(std::max(-10, std::min(10, v)) + 10);
 }
 
 } // namespace

--- a/tests/protocol/CapabilityDiscoveryTests.cpp
+++ b/tests/protocol/CapabilityDiscoveryTests.cpp
@@ -87,7 +87,7 @@ TEST_CASE("CapabilityDiscovery: discoverAsync runs non-blocking", "[protocol][ca
     auto caps = future.get();
     REQUIRE(caps.noiseCancelling == true);
     REQUIRE(caps.wearSensor == true);
-    REQUIRE(caps.equalizer == false);
+    REQUIRE(caps.equalizer == true);
 }
 
 TEST_CASE("CapabilityCache: persistence to file", "[protocol][capabilities]")

--- a/tests/protocol/DeviceProfileTests.cpp
+++ b/tests/protocol/DeviceProfileTests.cpp
@@ -48,7 +48,10 @@ TEST_CASE("DeviceProfileRegistry: provides immediate capabilities for known mode
         REQUIRE(profile->capabilities.noiseCancelling == true);
         REQUIRE(profile->capabilities.ambientSound == true);
         REQUIRE(profile->capabilities.focusOnVoice == true);
-        REQUIRE(profile->capabilities.equalizer == false);
+        REQUIRE(profile->capabilities.equalizer == true);
+        REQUIRE(profile->capabilities.clearBass == true);
+        REQUIRE(profile->capabilities.firmwareInfo == true);
+        REQUIRE(profile->capabilities.codecInfo == true);
         REQUIRE(profile->capabilities.dsee == false);
         REQUIRE(profile->capabilities.wearSensor == true);
         REQUIRE(profile->capabilities.multipoint == true);

--- a/tests/protocol/ProtocolV1Tests.cpp
+++ b/tests/protocol/ProtocolV1Tests.cpp
@@ -7,6 +7,24 @@ using namespace sony;
 using namespace sony::protocol;
 using namespace sony::transport;
 
+namespace {
+
+// First DataMdr payload the host transmitted (ACK frames are skipped).
+std::vector<uint8_t> firstRequestPayload(const FakeTransport& fake) {
+    for (const auto& frameBytes : fake.sentFrames()) {
+        auto decoded = FrameCodec::decode(frameBytes);
+        if (decoded.type == DataType::DataMdr) return decoded.payload;
+    }
+    return {};
+}
+
+void queueReply(FakeTransport& fake, std::vector<uint8_t> payload) {
+    fake.queueIncoming(FrameCodec::encode(SonyFrame{ .type = DataType::Ack, .sequence = 0 }));
+    fake.queueIncoming(FrameCodec::encode(SonyFrame{ .type = DataType::DataMdr, .sequence = 1, .payload = std::move(payload) }));
+}
+
+} // namespace
+
 TEST_CASE("ProtocolV1: explicit regression - battery request must NEVER send opcode 0x22", "[protocol][v1][regression]")
 {
     FakeTransport fake;
@@ -16,7 +34,8 @@ TEST_CASE("ProtocolV1: explicit regression - battery request must NEVER send opc
     ProtocolV1 v1(session);
     REQUIRE(v1.generation() == ProtocolGeneration::V1);
 
-    // Call getBattery()
+    // Single reading: 11 00 <50%> <charging>
+    queueReply(fake, {0x11, 0x00, 50, 1});
     auto battery = v1.getBattery();
 
     // Verify opcode 0x22 was NOT sent in ANY transmitted frame
@@ -25,6 +44,77 @@ TEST_CASE("ProtocolV1: explicit regression - battery request must NEVER send opc
         if (decoded.type == DataType::DataMdr && !decoded.payload.empty()) {
             REQUIRE(decoded.payload[0] != 0x22);
         }
+    }
+
+    // The legacy battery request is 10 00 and the reading is decoded from it
+    REQUIRE(firstRequestPayload(fake) == std::vector<uint8_t>{0x10, 0x00});
+    REQUIRE(battery.main.has_value());
+    REQUIRE(*battery.main == 50);
+    REQUIRE(battery.charging);
+    REQUIRE_FALSE(battery.left.has_value());
+    REQUIRE_FALSE(battery.caseBattery.has_value());
+}
+
+TEST_CASE("ProtocolV1: an over-ear dual reply with an empty right slot is a single reading", "[protocol][v1]")
+{
+    FakeTransport fake;
+    SonyProtocolSession session(&fake);
+    session.connect("11:22:33:44:55:66");
+    ProtocolV1 v1(session);
+
+    // Single query is acknowledged but never answered; the dual query then
+    // comes back as 11 01 <L=50> <chg> <R=0> <chg>, which is how a WH-1000XM4
+    // echoes its one cell.
+    fake.queueIncoming(FrameCodec::encode(SonyFrame{ .type = DataType::Ack, .sequence = 0 }));
+    fake.queueIncoming(FrameCodec::encode(SonyFrame{ .type = DataType::Ack, .sequence = 1 }));
+    fake.queueIncoming(FrameCodec::encode(SonyFrame{ .type = DataType::DataMdr, .sequence = 0, .payload = {0x11, 0x01, 50, 0, 0, 0} }));
+
+    auto battery = v1.getBattery();
+    REQUIRE(battery.main.has_value());
+    REQUIRE(*battery.main == 50);
+    REQUIRE_FALSE(battery.left.has_value());
+    REQUIRE_FALSE(battery.right.has_value());
+}
+
+TEST_CASE("ProtocolV1: decodes noise-control readback", "[protocol][v1]")
+{
+    FakeTransport fake;
+    SonyProtocolSession session(&fake);
+    session.connect("11:22:33:44:55:66");
+    ProtocolV1 v1(session);
+
+    SECTION("ambient sound with focus on voice")
+    {
+        // 67 02 <effect on> <ncType> <dualSingle off = ambient> <asmType> <voice> <level 5>
+        queueReply(fake, {0x67, 0x02, 0x01, 0x02, 0x00, 0x01, 0x01, 5});
+        auto nc = v1.getNoiseControl();
+        REQUIRE(firstRequestPayload(fake) == std::vector<uint8_t>{0x66, 0x02});
+        REQUIRE(nc.mode == NoiseControlMode::Ambient);
+        REQUIRE(nc.ambientLevel == 5);
+        REQUIRE(nc.focusOnVoice);
+    }
+
+    SECTION("noise cancelling")
+    {
+        queueReply(fake, {0x67, 0x02, 0x01, 0x02, 0x02, 0x01, 0x00, 0});
+        auto nc = v1.getNoiseControl();
+        REQUIRE(nc.mode == NoiseControlMode::NoiseCancelling);
+        REQUIRE(nc.ambientLevel == 0);
+        REQUIRE_FALSE(nc.focusOnVoice);
+    }
+
+    SECTION("off keeps no ambient level")
+    {
+        queueReply(fake, {0x67, 0x02, 0x00, 0x02, 0x00, 0x01, 0x00, 3});
+        auto nc = v1.getNoiseControl();
+        REQUIRE(nc.mode == NoiseControlMode::Off);
+        REQUIRE(nc.ambientLevel == 0);
+    }
+
+    SECTION("a truncated reply is rejected")
+    {
+        queueReply(fake, {0x67, 0x02, 0x01});
+        REQUIRE_THROWS_AS(v1.getNoiseControl(), SonyException);
     }
 }
 
@@ -36,24 +126,93 @@ TEST_CASE("ProtocolV1: sets noise control with V1 packet layout", "[protocol][v1
 
     // Host sends command and awaits ACK
     fake.queueIncoming(FrameCodec::encode(SonyFrame{ .type = DataType::Ack, .sequence = 0 }));
-
     ProtocolV1 v1(session);
-    NoiseControlState state{
-        .mode = NoiseControlMode::Ambient,
-        .ambientLevel = 7,
-        .focusOnVoice = true
-    };
-    v1.setNoiseControl(state);
 
-    REQUIRE(fake.sentCount() == 1);
-    auto sentFrame = FrameCodec::decode(fake.lastSentFrame());
-    REQUIRE(sentFrame.type == DataType::DataMdr);
-    REQUIRE(sentFrame.payload.size() == 8);
-    REQUIRE(sentFrame.payload[0] == 0x68); // NCASM_SET_PARAM
-    REQUIRE(sentFrame.payload[1] == 0x02); // V1 NC_ASM_INQUIRED_TYPE
-    REQUIRE(sentFrame.payload[2] == 17);   // ADJUSTMENT_COMPLETION
-    REQUIRE(sentFrame.payload[6] == 1);    // focus on voice = 1
-    REQUIRE(sentFrame.payload[7] == 7);    // level = 7
+    SECTION("ambient sound carries the level and focus-on-voice")
+    {
+        v1.setNoiseControl({ .mode = NoiseControlMode::Ambient, .ambientLevel = 7, .focusOnVoice = true });
+        REQUIRE(fake.sentCount() == 1);
+        auto sent = FrameCodec::decode(fake.lastSentFrame());
+        REQUIRE(sent.type == DataType::DataMdr);
+        REQUIRE(sent.payload == std::vector<uint8_t>{0x68, 0x02, 0x11, 0x01, 0x00, 0x01, 0x01, 7});
+    }
+
+    SECTION("noise cancelling is dual NC with the level at zero")
+    {
+        v1.setNoiseControl({ .mode = NoiseControlMode::NoiseCancelling, .ambientLevel = 7, .focusOnVoice = false });
+        auto sent = FrameCodec::decode(fake.lastSentFrame());
+        REQUIRE(sent.payload == std::vector<uint8_t>{0x68, 0x02, 0x11, 0x01, 0x02, 0x01, 0x00, 0});
+    }
+
+    SECTION("off clears the effect byte")
+    {
+        v1.setNoiseControl({ .mode = NoiseControlMode::Off, .ambientLevel = 7, .focusOnVoice = false });
+        auto sent = FrameCodec::decode(fake.lastSentFrame());
+        REQUIRE(sent.payload == std::vector<uint8_t>{0x68, 0x02, 0x00, 0x01, 0x00, 0x01, 0x00, 0});
+    }
+
+    SECTION("ambient level is clamped to the 1-20 range")
+    {
+        v1.setNoiseControl({ .mode = NoiseControlMode::Ambient, .ambientLevel = 0, .focusOnVoice = false });
+        auto sent = FrameCodec::decode(fake.lastSentFrame());
+        REQUIRE(sent.payload[7] == 1);
+    }
+}
+
+TEST_CASE("ProtocolV1: reads the equalizer behind inquired type 0x01", "[protocol][v1]")
+{
+    FakeTransport fake;
+    SonyProtocolSession session(&fake);
+    session.connect("11:22:33:44:55:66");
+    ProtocolV1 v1(session);
+
+    // 57 01 <Bass Boost> 06 <bass +5> <bands 0 1 2 3 4>
+    queueReply(fake, {0x57, 0x01, 0x16, 0x06, 15, 10, 11, 12, 13, 14});
+    auto eq = v1.getEqualizer();
+
+    REQUIRE(firstRequestPayload(fake) == std::vector<uint8_t>{0x56, 0x01});
+    REQUIRE(eq.preset == 0x16);
+    REQUIRE(eq.clearBass == 5);
+    REQUIRE(eq.bands == std::array<int, 5>{0, 1, 2, 3, 4});
+}
+
+TEST_CASE("ProtocolV1: writes equalizer presets and custom bands", "[protocol][v1]")
+{
+    FakeTransport fake;
+    SonyProtocolSession session(&fake);
+    session.connect("11:22:33:44:55:66");
+    ProtocolV1 v1(session);
+
+    fake.queueIncoming(FrameCodec::encode(SonyFrame{ .type = DataType::Ack, .sequence = 0 }));
+    v1.setEqualizerPreset(0x16);
+    REQUIRE(FrameCodec::decode(fake.sentFrames()[0]).payload == std::vector<uint8_t>{0x58, 0x01, 0x16, 0x00});
+
+    fake.queueIncoming(FrameCodec::encode(SonyFrame{ .type = DataType::Ack, .sequence = 1 }));
+    v1.setEqualizerCustom(5, {-10, 10, 0, 3, -3});
+    REQUIRE(FrameCodec::decode(fake.sentFrames()[1]).payload
+            == std::vector<uint8_t>{0x58, 0x01, 0xa0, 0x06, 15, 0, 20, 10, 13, 7});
+}
+
+TEST_CASE("ProtocolV1: reads firmware version and codec", "[protocol][v1]")
+{
+    FakeTransport fake;
+    SonyProtocolSession session(&fake);
+    session.connect("11:22:33:44:55:66");
+    ProtocolV1 v1(session);
+
+    SECTION("firmware is the ASCII tail after the length byte")
+    {
+        queueReply(fake, {0x05, 0x02, 0x05, '3', '.', '0', '.', '1'});
+        REQUIRE(v1.getFirmwareVersion() == "3.0.1");
+        REQUIRE(firstRequestPayload(fake) == std::vector<uint8_t>{0x04, 0x02});
+    }
+
+    SECTION("codec byte maps to its name")
+    {
+        queueReply(fake, {0x19, 0x00, 0x02});
+        REQUIRE(v1.getCodec() == "AAC");
+        REQUIRE(firstRequestPayload(fake) == std::vector<uint8_t>{0x18, 0x00});
+    }
 }
 
 TEST_CASE("ProtocolV1: sends VPT and sound position commands", "[protocol][v1]")
@@ -87,13 +246,10 @@ TEST_CASE("ProtocolV1: unsupported features throw Unsupported", "[protocol][v1]"
 
     ProtocolV1 v1(session);
 
-    REQUIRE_THROWS_AS(v1.getEqualizer(), SonyException);
-    REQUIRE_THROWS_AS(v1.setEqualizerPreset(1), SonyException);
     REQUIRE_THROWS_AS(v1.getDsee(), SonyException);
     REQUIRE_THROWS_AS(v1.setDsee(true), SonyException);
     REQUIRE_THROWS_AS(v1.getSpeakToChat(), SonyException);
     REQUIRE_THROWS_AS(v1.getAdaptiveVolume(), SonyException);
-    REQUIRE_THROWS_AS(v1.getFirmwareVersion(), SonyException);
-    REQUIRE_THROWS_AS(v1.getCodec(), SonyException);
     REQUIRE_THROWS_AS(v1.getAutoPowerOff(), SonyException);
+    REQUIRE(fake.sentCount() == 0);
 }


### PR DESCRIPTION
## What changed

`ProtocolV1::getBattery()` returned a cache that nothing ever filled, so every V1 device (WH-1000XM3/XM4 and older) showed its battery as unknown. `SonyDevice::refreshNoiseControl` skipped V1 outright, and the equalizer, firmware and codec getters threw `Unsupported`. This wires the legacy command set for all of them, using the byte layouts from `Client/CommandSerializer.cpp` and Gadgetbridge's `SonyProtocolImplV1`, each replayed against a WH-1000XM4 before being trusted:

- **Battery**: `10 00` → `11 00 <level> <charging>`, then the dual (`10 01`) and case (`10 02`) queries as a fallback for V1 earbuds. An over-ear device answers the dual query too, echoing its one cell into the left slot with the right at 0; that is folded back into a single reading instead of `min()` reporting 0 %.
- **Noise control readback**: `66 02` → `67 02 <effect> <ncType> <dualSingle> <asmType> <voice> <level>`. Effect 0 is off; dual/single `0x00` is ambient sound at `<level>`, anything else is noise cancelling.
- **Noise control write**: `setNoiseControl` sent noise cancelling as dual/single OFF with level `0xFF`, which the headset treats as ambient sound (the port lost the legacy `getDualSingleForAsmLevel` mapping). It now sends dual NC at level 0 / ambient at level 1–20 / effect 0 for off, which is what the device echoes back on GET.
- **Equalizer**: `56 01` / `57 01` / `58 01`. Same preset table and band encoding as V2, behind inquired type `0x01` instead of `0x00`.
- **Firmware** `04 02` → `05 02 <len> <ascii>` and **codec** `18 00` → `19 00 <codec>`.
- `SonyDevice::refreshNoiseControl` no longer short-circuits on V1. The WH-1000XM4 profile advertises `equalizer`, `clearBass`, `firmwareInfo` and `codecInfo`.
- `initDevice` poll timeout 500 → 1500 ms. The first reply after connecting is the slow one on the XM4; giving up early left its late ACK and data frame to collide with the next request, which is how the single battery query occasionally timed out into the dual fallback.
- `libs/sony-protocol/src/ProtocolHelpers.h` shares `codecName` / `clampEqValue` between the two generations instead of V1 growing a second copy.

Opcode `0x22` is still never emitted on V1 (#24). The regression test keeps that assertion and now also pins the `10 00` request and decodes the reply.

## Verified on hardware

WH-1000XM4, firmware 3.0.1, Windows 11, MSVC 2022 / Qt 6.10.3, direct Bluetooth session. End-to-end with `sonyctl --direct`, reading the state back after every write:

| command | readback |
| :--- | :--- |
| `anc on` | Noise Cancelling |
| `ambient 10` | Ambient (Level 10) |
| `anc off` | Off |
| `eq bass-boost` | Bass Boost, Clear Bass 7 |
| `eq off` | Off, bands 0 |
| `battery` | 50 %, stable across 10 consecutive reads |

Firmware reads `3.0.1`, codec `AAC`. The desktop app shows the battery ring, the current noise mode and the equalizer for the same device.

## Tests

- `ctest --test-dir build --output-on-failure`: 125/125 on MSVC 19.39 (the Unix socket test is skipped on Windows as before).
- `ProtocolV1Tests` grows from 4 to 9 cases: battery decode with the no-`0x22` assertion, the dual-echo fallback, noise-control decode (ambient / NC / off / truncated reply), the three write layouts plus level clamping, equalizer get and both writes, firmware and codec.
- `CapabilityDiscoveryTests` and `DeviceProfileTests` updated for the XM4 profile now advertising an equalizer.
- `git diff --check` clean.

## Not covered

- **WH-1000XM3**: same opcodes, but not re-tested here (no hardware). Only the XM4 row moves to Verified.
- **V1 DSEE and auto power-off**: the XM4 answers `e6 02` with `e7 02 00 00` and `f6 04` with `f7 04 01 10 00`; captured, not decoded or exposed.
- **`sonyctl --direct info` still prints Firmware/Codec as Unknown**, for every generation. Those are only read by the `DeviceService::tick()` maintenance steps, which the short-lived direct CLI never runs; the GUI shows them within a few seconds. Pre-existing, left alone here.
- Ambient level is reported as 0 while the mode is NC or Off, mirroring V2; the GUI's "level is out of range" when switching from ANC/Off (#34) is untouched.
- Docs: README table and paragraph, `docs/device-matrix.md` (the XM4 row was aspirational: tester "Baseline", firmware 2.5.0, EQ marked N/A), `ipc-and-lifecycle.md` and `technical-debt.md` now say what is actually verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TkKx1tVdk4P8ZgCFvWcb6M
