### PR TITLE
fix(device-center): pin the Basic style and drop the console window on Windows

### DIFF
--- a/apps/device-center/CMakeLists.txt
+++ b/apps/device-center/CMakeLists.txt
@@ -90,6 +90,11 @@ install(TARGETS sony-device-center
     BUNDLE  DESTINATION .)
 
 if(WIN32)
+    # A console-subsystem binary pops a terminal window next to the GUI on
+    # every launch. The app has no console UI, so build it as a GUI-subsystem
+    # executable; Qt6::Core supplies the WinMain shim.
+    set_target_properties(sony-device-center PROPERTIES WIN32_EXECUTABLE ON)
+
     # A bare .exe cannot start without the Qt DLLs and QML module tree beside
     # it, so let windeployqt populate the install prefix at install time.
     get_target_property(_qt_qmake Qt6::qmake IMPORTED_LOCATION)

--- a/apps/device-center/main.cpp
+++ b/apps/device-center/main.cpp
@@ -1,12 +1,19 @@
 #include <QGuiApplication>
 #include <QQmlApplicationEngine>
 #include <QQmlContext>
+#include <QQuickStyle>
 #include <QIcon>
 
 #include "DeviceCenterController.h"
 
 int main(int argc, char *argv[]) {
     QGuiApplication app(argc, argv);
+
+    // Main.qml customises background/handle/indicator on its controls. The
+    // native "Windows" and "macOS" styles Qt picks by default there refuse
+    // that (one warning per control, and native-looking widgets), so pin the
+    // one style that honours customisation on every platform.
+    QQuickStyle::setStyle("Basic");
     app.setApplicationName("Sony Device Center");
     app.setOrganizationName("SonyBridge");
     app.setApplicationVersion(SONY_DEVICE_CENTER_VERSION);


### PR DESCRIPTION
## What changed

Qt 6 picks the native "Windows" (and "macOS") Quick Controls style by default. `Main.qml` customises `background`, `handle`, `indicator` and `contentItem` on its controls, which those styles refuse: one warning per control on every launch (about sixty lines of `The current style does not support customization of this control`) and native-looking widgets instead of the app's own. `main.cpp` now pins `QQuickStyle::setStyle("Basic")` before the engine loads. Basic is already the default on Linux, so nothing changes there and the screenshots stay as they are.

The Windows target was also a console-subsystem executable, so a terminal window opened next to the GUI on every launch, whether by double-click, Start menu or `start`. It is now built with `WIN32_EXECUTABLE ON`; Qt6::Core supplies the WinMain shim and `main()` is unchanged. `sonyd` and `sonyctl` stay console applications.

## Tests

- Built and launched on Windows 11 with MSVC 2022 / Qt 6.10.3: zero style warnings, `dumpbin /headers` reports `2 subsystem (Windows GUI)`, no console window, and the app connects to a WH-1000XM4 as before.
- `ctest --test-dir build --output-on-failure`: 125/125 on a tree with this branch and #36 merged together (that is the build the hardware check above ran on). Nothing here touches a tested code path; `sony-ui-tests` links the same sources and is unaffected by the subsystem flag.

Independent of #36; either can land first.

## Not covered

- On Windows, the console window was the only place the app's log lines were visible when launched by double-click. With a GUI subsystem they are not shown anywhere; run `sonyctl -v` for protocol diagnostics instead.
- macOS gets the same `Basic` pin, which should silence the equivalent warnings there, but that was not run on a Mac.

Fixes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TkKx1tVdk4P8ZgCFvWcb6M
