### PR TITLE
fix(macos): prevent a crash when a Bluetooth connection attempt fails

### DIFF
--- a/Client/macos/MacOSBluetoothConnector.h
+++ b/Client/macos/MacOSBluetoothConnector.h
@@ -36,7 +36,7 @@ public:
     SonyProtocolVersion protocolVersion = SonyProtocolVersion::V1;
 
 private:
-    void *rfcommDevice;
-    void *rfcommchannel;
+    void *rfcommDevice = nullptr;
+    void *rfcommchannel = nullptr;
     std::thread uthread;
 };

--- a/Client/macos/MacOSBluetoothConnector.mm
+++ b/Client/macos/MacOSBluetoothConnector.mm
@@ -148,6 +148,9 @@ void MacOSBluetoothConnector::connectToMac(MacOSBluetoothConnector* macOSBluetoo
     lk.unlock();
 }
 void MacOSBluetoothConnector::connect(const std::string& addrStr){
+    // A failed attempt ends its thread without a join. Assigning a new thread
+    // over a joinable one calls std::terminate(), so release the old one first.
+    disconnect();
     // convert mac address to nsstring
     NSString *addressNSString = [NSString stringWithCString:addrStr.c_str() encoding:[NSString defaultCStringEncoding]];
     // get device based on mac address
@@ -230,8 +233,11 @@ void MacOSBluetoothConnector::disconnect() noexcept
     running = false;
     // notify the other thread that we are done disconnecting
     disconnectionConditionVariable.notify_all();
-    // wait for the thread to finish
-    uthread.join();
+    // wait for the thread to finish. The channel-closed callback calls this
+    // function on that thread, and a thread cannot join itself.
+    if (uthread.joinable() && uthread.get_id() != std::this_thread::get_id()) {
+        uthread.join();
+    }
 }
 void MacOSBluetoothConnector::closeConnection() {
     // get the channel


### PR DESCRIPTION
A failed connection attempt ended its connector thread, but nothing joined that thread. The next attempt then assigned a new thread to the joinable std::thread member, and the app called std::terminate. On macOS, discovery lists every paired device, so the first attempt fails on most Macs and the app crashed at startup in direct Bluetooth mode.

connect() now calls disconnect() first, which joins the old thread. disconnect() does not join the current thread, because the channel-closed callback calls it on the connector thread. The device and channel pointers now start as nullptr, because disconnect() now runs before the first connection.

Tested on my Mac running macOS 26.6.2