### PR TITLE
fix(protocol): reject out-of-range EQ preset values

### DIFF
--- a/libs/sony-core/src/IpcProtocol.cpp
+++ b/libs/sony-core/src/IpcProtocol.cpp
@@ -279,7 +279,7 @@ IpcResponse IpcProtocol::execute(const IpcCommand& cmd, IDeviceService& service)
                 presetName = cmd.args[1];
             }
             int preset = parsePresetName(presetName);
-            if (preset < 0) {
+            if (preset < 0 || preset > 255) {
                 resp.success = false;
                 resp.message = "Unknown preset: " + presetName;
                 return resp;

--- a/libs/sony-core/src/SonyDevice.cpp
+++ b/libs/sony-core/src/SonyDevice.cpp
@@ -280,6 +280,7 @@ void SonyDevice::setAmbient(int level, bool focusOnVoice) {
 }
 
 void SonyDevice::setEqualizerPreset(int preset) {
+    if (preset < 0 || preset > 255) return;
     if (!_protocol) return;
     _protocol->setEqualizerPreset(preset);
     {

--- a/tests/core/IpcProtocolTests.cpp
+++ b/tests/core/IpcProtocolTests.cpp
@@ -231,6 +231,14 @@ TEST_CASE("IpcProtocol execution through DeviceService", "[core][ipc]") {
         CHECK(eqResp.success);
         CHECK(service.snapshot()->equalizer.preset == 0x16);
 
+        for (const auto* preset : {"256", "272"}) {
+            auto invalidEqResp = IpcProtocol::execute(
+                IpcProtocol::parseCommand(std::string("eq preset ") + preset), service);
+            CHECK_FALSE(invalidEqResp.success);
+            CHECK(invalidEqResp.message == std::string("Unknown preset: ") + preset);
+            CHECK(service.snapshot()->equalizer.preset == 0x16);
+        }
+
         // EQ Get
         auto eqGetResp = IpcProtocol::execute(IpcProtocol::parseCommand("eq get"), service);
         CHECK(eqGetResp.success);

--- a/tests/core/SonyDeviceTests.cpp
+++ b/tests/core/SonyDeviceTests.cpp
@@ -154,6 +154,14 @@ TEST_CASE("SonyDevice control methods and state updates", "[core][device]") {
         auto snap = dev.snapshot();
         CHECK(snap->equalizer.preset == 0x16);
         CHECK(eqChangeCount.load() >= 1);
+
+        for (int preset : {-1, 256, 272}) {
+            dev.setEqualizerPreset(preset);
+            auto unchanged = dev.snapshot();
+            CHECK(unchanged->equalizer.preset == snap->equalizer.preset);
+            CHECK(unchanged->equalizer.clearBass == snap->equalizer.clearBass);
+            CHECK(unchanged->equalizer.bands == snap->equalizer.bands);
+        }
     }
 
     SECTION("Equalizer custom control") {


### PR DESCRIPTION
## What

`EqualizerPresets.cpp`'s `equalizerPresetFromName()` falls back to a bare `std::stoi()` for numeric input with no upper bound (e.g. `"272"` parses to `272`). `IpcProtocol.cpp`'s `EqPreset` case only rejected `preset < 0` before calling `dev->setEqualizerPreset(preset)`, and both `ProtocolV1::setEqualizerPreset`/`ProtocolV2::setEqualizerPreset` truncate to `uint8_t` on the wire — so e.g. `sonyctl eq preset 272` silently sends preset `16` (Bright) to the headphones while the daemon's cached `_state.equalizer.preset` and the response message both still claim preset `272`.

## Fix

- `IpcProtocol.cpp`: widen the existing `if (preset < 0)` check to `if (preset < 0 || preset > 255)`, so IPC callers get a proper `"Unknown preset: N"` error instead of a silent wire truncation.
- `SonyDevice.cpp`: add the same range check as the first line of `SonyDevice::setEqualizerPreset`, before it touches `_protocol` or `_state`. This is the shared choke point every current and future caller funnels through — defense in depth, not just a duplicate of the IPC check.

Both fixes are needed because there's no reason to assume `IpcProtocol::execute` will always be the only caller of `SonyDevice::setEqualizerPreset` going forward (it wasn't, historically — an earlier revision of the desktop GUI had a direct in-process fallback that bypassed it entirely).

Also relevant to #36: that PR's new `ProtocolV1::setEqualizerPreset` implementation has the identical unvalidated `static_cast<uint8_t>(preset)` truncation `ProtocolV2` already had, so this fix protects V1 devices too once #36 lands — no file overlap between the two PRs (this one doesn't touch `ProtocolV1.cpp`/`ProtocolV2.cpp` at all).

## Testing

Added regression tests to `IpcProtocolTests.cpp` (asserts `eq preset 256`/`272` are rejected via IPC with the correct error message) and `SonyDeviceTests.cpp` (asserts `SonyDevice::setEqualizerPreset` leaves state unchanged for `-1`/`256`/`272`). Full suite passes (123/123).

Also verified live against a real WH-1000XM6: `eq preset 272`/`eq preset -1` are rejected, `eq preset 22` (Bass Boost) and other in-range presets still reach the device correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)