### PR TITLE
packaging(arch): add a PKGBUILD for pacman/AUR installs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -387,6 +387,15 @@ _pkginfo.txt
 *.appxbundle
 *.appxupload
 
+# Arch Linux makepkg build artifacts
+packaging/arch/src/
+packaging/arch/pkg/
+packaging/arch/*.pkg.tar.*
+packaging/arch/*.log
+# makepkg's local VCS source-cache when SRCDEST is unset (mirrors the
+# clone under the package name, e.g. sony-device-center-git/)
+packaging/arch/*-git/
+
 # Visual Studio cache files
 # files ending in .cache can be ignored
 *.[Cc]ache

--- a/README.md
+++ b/README.md
@@ -104,7 +104,16 @@ that is the only way this table improves. `sonyctl -v info` output is ideal.
        gcc-c++ cmake git \
        bluez-libs-devel dbus-devel glfw-devel \
        qt6-qtbase-devel qt6-qtdeclarative-devel
+
+   # Arch
+   sudo pacman -S --needed \
+       base-devel cmake git \
+       bluez-libs dbus glfw \
+       qt6-base qt6-declarative
    ```
+   On Arch, `packaging/arch/PKGBUILD` builds and installs this as a proper
+   pacman package instead (`cd packaging/arch && makepkg -si`) — see
+   [`packaging/README.md`](packaging/README.md#arch-linux-pkgbuild).
 
 2. **Install submodules**:
    ```bash

--- a/packaging/README.md
+++ b/packaging/README.md
@@ -39,6 +39,18 @@ flatpak-builder --force-clean build-dir packaging/linux/com.github.sonybridge.so
 flatpak-builder --run build-dir packaging/linux/com.github.sonybridge.sony-device-center.yml sony-device-center
 ```
 
+### Arch Linux (PKGBUILD)
+No tagged release exists yet, so `packaging/arch/PKGBUILD` tracks `main` as a
+`-git` VCS package — the standard AUR convention for software without
+releases. Build and install it with `makepkg`:
+```bash
+cd packaging/arch
+makepkg -si
+```
+This registers the install with pacman (clean upgrades/removal via
+`sony-device-center-git`), unlike a manual `cmake --install`. Fill in the
+`# Maintainer` line before publishing it to the AUR.
+
 ### Systemd Service
 To run the `sonyd` background daemon automatically at user login:
 ```bash

--- a/packaging/arch/PKGBUILD
+++ b/packaging/arch/PKGBUILD
@@ -1,0 +1,48 @@
+# There is no tagged release yet, so this tracks the main branch as a
+# -git VCS package (the standard AUR convention for unreleased software).
+# Once the project starts tagging releases, switch this to a regular
+# tarball-based PKGBUILD instead.
+# Add a `# Maintainer:` comment above pkgname before publishing to the AUR.
+
+pkgname=sony-device-center-git
+pkgver=0.1.5.r101.g2c1d89b
+pkgrel=1
+pkgdesc="Desktop suite and CLI/daemon for Sony headphones (ANC, Ambient Sound, Equalizer, DSEE, battery) over Bluetooth, without the mobile app"
+arch=('x86_64')
+url="https://github.com/marconvcm/sony-device-center"
+license=('MIT')
+depends=('qt6-base' 'qt6-declarative' 'bluez-libs' 'dbus')
+makedepends=('cmake' 'git' 'glfw' 'mesa')
+provides=('sony-device-center' 'sonyctl' 'sonyd')
+conflicts=('sony-device-center')
+source=("$pkgname::git+$url.git")
+sha256sums=('SKIP')
+
+pkgver() {
+    cd "$pkgname"
+    printf "%s.r%s.g%s" \
+        "$(sed -n 's/^project(SonyDeviceCenter VERSION \([0-9.]*\).*/\1/p' CMakeLists.txt)" \
+        "$(git rev-list --count HEAD)" \
+        "$(git rev-parse --short HEAD)"
+}
+
+prepare() {
+    cd "$pkgname"
+    # Client/imgui is a submodule needed by the legacy ImGui client target,
+    # which the top-level build still configures and compiles on Linux.
+    git submodule update --init --recursive
+}
+
+build() {
+    cmake -B build -S "$pkgname" \
+        -DCMAKE_BUILD_TYPE=Release \
+        -DCMAKE_INSTALL_PREFIX=/usr \
+        -DBUILD_TESTING=OFF \
+        -DSONY_REQUIRE_QT=ON
+    cmake --build build
+}
+
+package() {
+    DESTDIR="$pkgdir" cmake --install build
+    install -Dm644 "$pkgname/LICENSE" "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
+}


### PR DESCRIPTION
No tagged release exists yet, so it tracks main as a -git VCS package, the standard AUR convention for unreleased software. Building it installs sonyd/sonyctl/sony-device-center plus the desktop file, icons, metainfo, and systemd user service through the existing cmake --install rules, and registers the install with pacman for clean upgrades/removal instead of a bare cmake --install.

Also fills in the pacman dependency list in the Linux prerequisites section, which only had apt/dnf commands despite the heading naming Arch.